### PR TITLE
Add CI config for web CI integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:local": "ENV=local playwright test",
     "test:dev01": "ENV=dev01 playwright test  ./tests/minimal/",
     "test:int01": "ENV=int01 playwright test  ./tests/minimal/",
+    "test:web:dev01": "ENV=dev01 playwright test  ./tests/web/",
+    "test:web:int01": "ENV=int01 playwright test  ./tests/web/",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --fix",
     "format": "biome format .",

--- a/playwright.ci.config.ts
+++ b/playwright.ci.config.ts
@@ -62,5 +62,10 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
-  ]
+  ],
+  webServer: {
+    // use the dist folder to start devserver in CI
+    command: "npx serve dist -l 8088",
+    port: 8088,
+  },
 });


### PR DESCRIPTION
The new file playwright.ci.config.ts only add a webserver config to start during a web CI action run. It will replace the standard playwirght config during the trigger of the action