### PR TITLE
Integration API : test room access rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "mas-playwright-tests",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "matrix-js-sdk": "^41.5.0"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.11",
         "@playwright/test": "^1.40.0",
@@ -15,6 +18,15 @@
         "dotenv": "^16.3.1",
         "mailpit-api": "^1.5.4",
         "typescript": "^5.3.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -180,6 +192,15 @@
         "node": ">=14.21.3"
       }
     },
+    "node_modules/@matrix-org/matrix-sdk-crypto-wasm": {
+      "version": "18.3.0",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-18.3.0.tgz",
+      "integrity": "sha512-9a4feyt8QLysARu7PHKaRWT+wcCd+IYH074LXp9QK5WqfN4zUXueRhiSSMNT18Bm+8q3sBR/4zxDxOSDR0M8Kg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
@@ -196,6 +217,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@types/events": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.17.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
@@ -204,6 +231,12 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
+    },
+    "node_modules/another-json": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/another-json/-/another-json-0.2.0.tgz",
+      "integrity": "sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==",
+      "license": "Apache-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -222,6 +255,21 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -249,6 +297,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/delayed-stream": {
@@ -335,6 +392,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/follow-redirects": {
@@ -482,9 +548,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -492,6 +558,40 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-network-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/mailpit-api": {
@@ -517,6 +617,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/matrix-events-sdk": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz",
+      "integrity": "sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/matrix-js-sdk": {
+      "version": "41.5.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-41.5.0.tgz",
+      "integrity": "sha512-CK3h+qQJ4wkVEUgEWc5MdLjccXyiFqncCC53P+auqOhnX2U6tAFsRfnbML1QQiKIsFMzqTrAnF/4a5LUUOIeXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@matrix-org/matrix-sdk-crypto-wasm": "^18.2.0",
+        "another-json": "^0.2.0",
+        "bs58": "^6.0.0",
+        "content-type": "^1.0.4",
+        "jwt-decode": "^4.0.0",
+        "loglevel": "^1.9.2",
+        "matrix-events-sdk": "0.0.1",
+        "matrix-widget-api": "^1.16.1",
+        "oidc-client-ts": "^3.0.1",
+        "p-retry": "8",
+        "sdp-transform": "^3.0.0",
+        "unhomoglyph": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/matrix-widget-api": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/matrix-widget-api/-/matrix-widget-api-1.17.0.tgz",
+      "integrity": "sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/events": "^3.0.0",
+        "events": "^3.2.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -538,6 +678,33 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.5.0.tgz",
+      "integrity": "sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-8.0.0.tgz",
+      "integrity": "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-network-error": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/playwright": {
@@ -582,11 +749,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/sdp-transform": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-3.0.0.tgz",
+      "integrity": "sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -600,6 +777,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
+    },
+    "node_modules/unhomoglyph": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/unhomoglyph/-/unhomoglyph-1.0.6.tgz",
+      "integrity": "sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test:local": "ENV=local playwright test",
     "test:dev01": "ENV=dev01 playwright test  ./tests/minimal/",
     "test:int01": "ENV=int01 playwright test  ./tests/minimal/",
+    "test:room:dev01": "ENV=dev01 playwright test ./tests/room-access-rules/",
+    "test:room:int01": "ENV=int01 playwright test ./tests/room-access-rules/",
+    "test:all": "playwright test",
     "lint": "biome lint .",
     "lint:fix": "biome lint . --fix",
     "format": "biome format .",
@@ -24,6 +27,9 @@
   ],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "matrix-js-sdk": "^41.5.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",
     "@playwright/test": "^1.40.0",

--- a/tests/room-access-rules/direct-room.spec.ts
+++ b/tests/room-access-rules/direct-room.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import type { MatrixApi } from '../../utils/matrix-api';
+import { deactivateMasUser } from '../../utils/mas-admin';
+import { expectErrorWhenSendStateEvent, loginWithNewUser } from './room-utils';
+import { EventType, JoinRule } from 'matrix-js-sdk';
+
+export async function createDirectRoom(
+  matrix: MatrixApi,
+  name: string = 'Direct Room'
+): Promise<string> {
+  return matrix.createRoom({
+    name,
+    joinRule: 'invite',
+    preset: 'trusted_private_chat',
+    visibility: 'private',
+    encryption: false,
+    accessRules: {
+      rule: 'direct',
+      force_unencrypted_at_creation: false,
+      visibility: 'private',
+    },
+    is_direct: true,
+  });
+}
+
+test.describe('API - Direct Room', () => {
+  let matrix: MatrixApi;
+  let userId: string;
+
+  test.beforeAll(async () => {
+    const userData = await loginWithNewUser();
+    userId = userData.userId;
+    matrix = userData.matrix;
+  });
+
+  test('Should create direct room with correct properties', async () => {
+    const roomId = await createDirectRoom(matrix);
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('direct');
+    expect(accessRules.force_unencrypted_at_creation).toBe(false);
+    expect(accessRules.visibility).toBe('private');
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(true);
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should return 403 error when changing joining rule', async () => {
+    const roomId = await createDirectRoom(matrix);
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      EventType.RoomJoinRules,
+      { join_rule: JoinRule.Public },
+      403
+    );
+  });
+
+  test('Should return 403 error when changing access rules', async () => {
+    const roomId = await createDirectRoom(matrix);
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'unrestricted' },
+      403
+    );
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'restricted' },
+      403
+    );
+  });
+
+  test.afterAll(async () => {
+    await deactivateMasUser(userId);
+  });
+});

--- a/tests/room-access-rules/private-encrypted-room.spec.ts
+++ b/tests/room-access-rules/private-encrypted-room.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { BASE_URL, TEST_USER_PASSWORD } from '../../utils/config';
+import type { MatrixApi } from '../../utils/matrix-api';
+import { createMasUserWithPassword, deactivateMasUser } from '../../utils/mas-admin';
+import { expectErrorWhenSendStateEvent, loginWithNewUser } from './room-utils';
+import { EventType, JoinRule } from 'matrix-js-sdk';
+
+export async function createPrivateEncryptedRoom(
+  matrix: MatrixApi,
+  name: string = 'Private Room'
+): Promise<string> {
+  return matrix.createRoom({
+    name,
+    joinRule: 'invite',
+    preset: 'private_chat',
+    visibility: 'private',
+    accessRules: {
+      rule: 'restricted',
+      force_unencrypted_at_creation: false,
+      visibility: 'private',
+    },
+  });
+}
+
+test.describe('API - Private Encrypted Room', () => {
+  let matrix: MatrixApi;
+  let userId: string;
+
+  test.beforeAll(async () => {
+    const userData = await loginWithNewUser();
+    userId = userData.userId;
+    matrix = userData.matrix;
+  });
+
+  test('Should create private encrypted room with correct properties', async () => {
+    const roomId = await createPrivateEncryptedRoom(matrix);
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('restricted');
+    expect(accessRules.force_unencrypted_at_creation).toBe(false);
+    expect(accessRules.visibility).toBe('private');
+
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(true);
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should modify joinRule between invite and public', async () => {
+    const roomId = await createPrivateEncryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, EventType.RoomJoinRules, { join_rule: JoinRule.Public });
+
+    expect(await matrix.getJoinRule(roomId)).toBe('public');
+
+    await matrix.sendStateEvent(roomId, EventType.RoomJoinRules, { join_rule: JoinRule.Invite });
+
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should change access rules from restricted to unrestricted', async () => {
+    const roomId = await createPrivateEncryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, 'im.vector.room.access_rules', { rule: 'unrestricted' });
+
+    expect((await matrix.getAccessRules(roomId)).rule).toBe('unrestricted');
+  });
+
+  test('Should return 403 error when changing access rules back to restricted', async () => {
+    const roomId = await createPrivateEncryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, 'im.vector.room.access_rules', { rule: 'unrestricted' });
+    expect((await matrix.getAccessRules(roomId)).rule).toBe('unrestricted');
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'restricted' },
+      403
+    );
+  });
+
+  test.afterAll(async () => {
+    await deactivateMasUser(userId);
+  });
+});

--- a/tests/room-access-rules/private-unencrypted-room.spec.ts
+++ b/tests/room-access-rules/private-unencrypted-room.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { BASE_URL, TEST_USER_PASSWORD } from '../../utils/config';
+import type { MatrixApi } from '../../utils/matrix-api';
+import { createMasUserWithPassword, deactivateMasUser } from '../../utils/mas-admin';
+import { expectErrorWhenSendStateEvent, loginWithNewUser } from './room-utils';
+import { EventType, JoinRule } from 'matrix-js-sdk';
+
+export async function createPrivateUnencryptedRoom(
+  matrix: MatrixApi,
+  name: string = 'Private Unencrypted Room'
+): Promise<string> {
+  return matrix.createRoom({
+    name,
+    joinRule: 'invite',
+    preset: 'private_chat',
+    visibility: 'private',
+    encryption: false,
+    accessRules: {
+      rule: 'restricted',
+      force_unencrypted_at_creation: true,
+      visibility: 'private',
+    },
+  });
+}
+
+test.describe('API - Private Unencrypted Room', () => {
+  let matrix: MatrixApi;
+  let userId: string;
+
+  test.beforeAll(async () => {
+    const userData = await loginWithNewUser();
+    userId = userData.userId;
+    matrix = userData.matrix;
+  });
+
+  test('Should create private unencrypted room with correct properties', async () => {
+    const roomId = await createPrivateUnencryptedRoom(matrix);
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('restricted');
+    expect(accessRules.force_unencrypted_at_creation).toBe(true);
+    expect(accessRules.visibility).toBe('private');
+
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(false);
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should modify joinRule between invite and public', async () => {
+    const roomId = await createPrivateUnencryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, EventType.RoomJoinRules, { join_rule: JoinRule.Public });
+
+    expect(await matrix.getJoinRule(roomId)).toBe('public');
+
+    await matrix.sendStateEvent(roomId, EventType.RoomJoinRules, { join_rule: JoinRule.Invite });
+
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should change access rules from restricted to unrestricted', async () => {
+    const roomId = await createPrivateUnencryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, 'im.vector.room.access_rules', { rule: 'unrestricted' });
+
+    expect((await matrix.getAccessRules(roomId)).rule).toBe('unrestricted');
+  });
+
+  test('Should return 403 error when changing access rules back to restricted', async () => {
+    const roomId = await createPrivateUnencryptedRoom(matrix);
+
+    await matrix.sendStateEvent(roomId, 'im.vector.room.access_rules', { rule: 'unrestricted' });
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'restricted' },
+      403
+    );
+  });
+
+  test.afterAll(async () => {
+    await deactivateMasUser(userId);
+  });
+});

--- a/tests/room-access-rules/public-room.spec.ts
+++ b/tests/room-access-rules/public-room.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { BASE_URL, TEST_USER_PASSWORD } from '../../utils/config';
+import type { MatrixApi } from '../../utils/matrix-api';
+import { createMasUserWithPassword, deactivateMasUser } from '../../utils/mas-admin';
+import { expectErrorWhenSendStateEvent, loginWithNewUser } from './room-utils';
+import { EventType } from 'matrix-js-sdk';
+
+export async function createPublicRoom(
+  matrix: MatrixApi,
+  name: string = 'Public Room'
+): Promise<string> {
+  return matrix.createRoom({
+    name,
+    joinRule: 'public',
+    preset: 'public_chat',
+    visibility: 'public',
+    accessRules: {
+      rule: 'restricted',
+      force_unencrypted_at_creation: false,
+      visibility: 'public',
+    },
+    power_level_content_override:{
+      events:
+      {
+         "m.room.name": 50,
+          "m.room.avatar": 50,
+          "m.room.power_levels": 100,
+          "m.room.history_visibility": 100,
+          "m.room.canonical_alias": 50,
+          "m.room.tombstone": 100,
+          "m.room.server_acl": 100,
+          "m.room.encryption": 100,
+          "org.matrix.msc3401.call.member": 0
+      },
+    }
+  });
+}
+
+test.describe('API - Public Room', () => {
+  let userId: string;
+  let matrix: MatrixApi;
+
+  test.beforeAll(async () => {
+    const userData = await loginWithNewUser();
+    userId = userData.userId;
+    matrix = userData.matrix;
+  });
+
+  test('Should create public room with correct properties', async () => {
+    const roomId = await createPublicRoom(matrix);
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('restricted');
+    expect(accessRules.force_unencrypted_at_creation).toBe(false);
+    expect(accessRules.visibility).toBe('public');
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(false);
+    expect(await matrix.getJoinRule(roomId)).toBe('public');
+  });
+
+  test('Should return 403 error when changing access rules to unrestricted', async () => {
+    const roomId = await createPublicRoom(matrix);
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'unrestricted' },
+      403
+    );
+  });
+
+  test('Should return 403 error when changing encryption', async () => {
+    const roomId = await createPublicRoom(matrix);
+
+    await expectErrorWhenSendStateEvent(matrix, roomId, EventType.RoomEncryption, {}, 403);
+  });
+
+  test.afterAll(async () => {
+    await deactivateMasUser(userId);
+  });
+});

--- a/tests/room-access-rules/room-utils.ts
+++ b/tests/room-access-rules/room-utils.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import { MatrixApi } from '../../utils/matrix-api';
+import type { StateEvents } from 'matrix-js-sdk';
+import { BASE_URL, STANDARD_EMAIL_DOMAIN, TEST_USER_PASSWORD } from '../../utils/config';
+import { createMasUserWithPassword } from '../../utils/mas-admin';
+
+/**
+ * Helper function to login with a new user
+ * Creates a new MAS user and returns the userId, username, and authenticated MatrixApi instance
+ */
+export async function loginWithNewUser(): Promise<{
+  userId: string;
+  username: string;
+  matrix: MatrixApi;
+}> {
+  const username = `user.${Date.now()}`;
+  const userId = await createMasUserWithPassword(
+    username,
+    `${username}@${STANDARD_EMAIL_DOMAIN}`,
+    TEST_USER_PASSWORD
+  );
+
+  const matrix = new MatrixApi(BASE_URL);
+  await matrix.login(username, TEST_USER_PASSWORD);
+
+  return { userId, username, matrix };
+}
+
+/**
+ * Helper function to test that sending a state event returns an error with the expected status code
+ */
+export async function expectErrorWhenSendStateEvent(
+  matrix: MatrixApi,
+  roomId: string,
+  eventType: string,
+  content: Record<string, any>,
+  expectedStatus: number = 403
+): Promise<void> {
+  try {
+    await matrix.sendStateEvent(roomId, eventType, content);
+    throw new Error(`Expected ${expectedStatus} error but request succeeded`);
+  } catch (error: any) {
+    expect(error.httpStatus).toBe(expectedStatus);
+  }
+}

--- a/tests/room-access-rules/room.spec.ts
+++ b/tests/room-access-rules/room.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+import { BASE_URL, TEST_USER_PASSWORD } from '../../utils/config';
+import type { MatrixApi } from '../../utils/matrix-api';
+import { createMasUserWithPassword, deactivateMasUser } from '../../utils/mas-admin';
+import { expectErrorWhenSendStateEvent, loginWithNewUser } from './room-utils';
+import { createPrivateEncryptedRoom } from './private-encrypted-room.spec';
+
+test.describe('API - Public Room', () => {
+  let matrix: MatrixApi;
+  let userId: string;
+
+  test.beforeAll(async () => {
+    const userData = await loginWithNewUser();
+    userId = userData.userId;
+    matrix = userData.matrix;
+  });
+
+  test('Should create private room without access rules', async () => {
+    const roomId = await matrix.createRoom({
+      name: 'name',
+      joinRule: 'invite',
+      preset: 'private_chat',
+      visibility: 'private',
+    });
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('restricted');
+    expect(accessRules.visibility).toBe('private');
+    expect(accessRules.force_unencrypted_at_creation).toBe(undefined);
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(true);
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should create public room without access rules', async () => {
+    const roomId = await matrix.createRoom({
+      name: 'name',
+      joinRule: 'public',
+      preset: 'public_chat',
+      visibility: 'public',
+    });
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('restricted');
+    expect(accessRules.visibility).toBe('public');
+    expect(accessRules.force_unencrypted_at_creation).toBe(undefined);
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(false);
+    expect(await matrix.getJoinRule(roomId)).toBe('public');
+  });
+
+  test('Should create direct room without access rules', async () => {
+    const roomId = await matrix.createRoom({
+      name: 'name',
+      joinRule: 'invite',
+      preset: 'trusted_private_chat',
+      visibility: 'private',
+      is_direct: true,
+    });
+    expect(roomId).toBeDefined();
+
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules).toBeDefined();
+    expect(accessRules.rule).toBe('direct');
+    expect(accessRules.visibility).toBe('private');
+    expect(accessRules.force_unencrypted_at_creation).toBe(undefined);
+    expect(await matrix.isRoomEncrypted(roomId)).toBe(true);
+    expect(await matrix.getJoinRule(roomId)).toBe('invite');
+  });
+
+  test('Should return 403 error when changing visibility', async () => {
+    const roomId = await createPrivateEncryptedRoom(matrix);
+    
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules.visibility).toBe('private');
+
+    //remove visibility should not be possible
+    await matrix.sendStateEvent(roomId, 'im.vector.room.access_rules', {rule: 'restricted'});
+    const newAccessRules = await matrix.getAccessRules(roomId);
+    expect(newAccessRules.visibility).toBe(undefined);
+
+    //set a visibility when undefined should not be possible
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'restricted', visibility:'public' },
+      403
+    );
+  });
+
+  test('Should return 403 error when changing force_unencrypted_at_creation', async () => {
+    const roomId = await matrix.createRoom({
+      name: 'name',
+      joinRule: 'invite',
+      preset: 'trusted_private_chat',
+      is_direct: true,
+    });
+  
+    const accessRules = await matrix.getAccessRules(roomId);
+    expect(accessRules.force_unencrypted_at_creation).toBe(undefined);
+
+    await expectErrorWhenSendStateEvent(
+      matrix,
+      roomId,
+      'im.vector.room.access_rules',
+      { rule: 'restricted', force_unencrypted_at_creation:true },
+      403
+    );
+  });
+
+  test.afterAll(async () => {
+    await deactivateMasUser(userId);
+  });
+});

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -100,7 +100,7 @@ export interface Credentials {
  */
 export class ClientServerApi extends Api {
   public constructor(baseUrl: string, request: APIRequestContext) {
-    super(`${baseUrl}/_matrix/client`);
+    super(`${baseUrl}`);
     this.setRequest(request);
   }
 

--- a/utils/matrix-api.ts
+++ b/utils/matrix-api.ts
@@ -1,0 +1,171 @@
+import { createClient, type StateEvents, type MatrixClient } from 'matrix-js-sdk';
+
+export interface AccessRules {
+  rule: 'restricted' | 'direct' | 'unrestricted';
+  force_unencrypted_at_creation?: boolean;
+  visibility?: 'public' | 'private';
+}
+
+export interface RoomCreationOptions {
+  name: string;
+  topic?: string;
+  accessRules?: AccessRules;
+  encryption?: boolean;
+  visibility?: 'public' | 'private';
+  joinRule?: 'invite' | 'knock' | 'public' | 'private';
+  preset: 'public_chat' | 'private_chat' | 'trusted_private_chat';
+  is_direct?: boolean;
+  power_level_content_override?:any
+  creation_content?:any
+}
+
+export class MatrixApi {
+  private client: MatrixClient;
+  private baseUrl: string;
+
+  public constructor(baseUrl: string) {
+    this.baseUrl = baseUrl;
+    this.client = createClient({
+      baseUrl: `${baseUrl}`,
+    });
+  }
+
+  /**
+   * Login a user
+   */
+  public async login(username: string, password: string): Promise<string> {
+    const response = await this.client.loginRequest({
+      type: 'm.login.password',
+      user: username,
+      password: password,
+    });
+
+    // Create a new MatrixClient instance with the token
+    this.client = createClient({
+      baseUrl: `${this.baseUrl}`,
+      accessToken: response.access_token,
+      userId: response.user_id,
+      deviceId: response.device_id,
+    });
+
+    return response.access_token;
+  }
+
+  /**
+   * Create a room
+   */
+  public async createRoom(options: RoomCreationOptions): Promise<string> {
+    const initialState: any[] = [];
+
+    // Add join_rule
+    if (options.joinRule) {
+      initialState.push({
+        type: 'm.room.join_rules',
+        state_key: '',
+        content: { join_rule: options.joinRule },
+      });
+    }
+
+    // Add access control rules
+    if (options.accessRules) {
+      const content: any = {};
+      if (options.accessRules.rule) {
+        content.rule = options.accessRules.rule;
+      }
+      if (options.accessRules.force_unencrypted_at_creation !== undefined) {
+        content.force_unencrypted_at_creation = options.accessRules.force_unencrypted_at_creation;
+      }
+      if (options.accessRules.visibility) {
+        content.visibility = options.accessRules.visibility;
+      }
+
+      initialState.push({
+        type: 'im.vector.room.access_rules',
+        state_key: '',
+        content: content,
+      });
+    }
+
+    const response = await this.client.createRoom({
+      name: options.name,
+      topic: options.topic,
+      visibility: options.visibility as any,
+      preset: options.preset as any,
+      initial_state: initialState as any,
+      is_direct: options.is_direct,
+      power_level_content_override: options.power_level_content_override,
+      creation_content: options.creation_content
+    });
+
+    return response.room_id;
+  }
+
+  /**
+   * Get room state
+   */
+  public async getRoomState(roomId: string): Promise<Record<string, any>> {
+    const state: Record<string, any> = {};
+
+    const eventTypes = [
+      'm.room.encryption',
+      'm.room.join_rules',
+      'im.vector.room.access_rules',
+      'm.room.create',
+      'm.room.name',
+    ];
+
+    for (const eventType of eventTypes) {
+      try {
+        const event = await this.client.getStateEvent(roomId, eventType, '');
+        state[eventType] = event;
+      } catch (e) {
+        console.log('event not found', eventType);
+      }
+    }
+
+    return state;
+  }
+
+  /**
+   * Check if room is encrypted
+   */
+  public async isRoomEncrypted(roomId: string): Promise<boolean> {
+    const state = await this.getRoomState(roomId);
+    return 'm.room.encryption' in state;
+  }
+
+  /**
+   * Get join rule
+   */
+  public async getJoinRule(roomId: string): Promise<any> {
+    const state = await this.getRoomState(roomId);
+    return state['m.room.join_rules']?.join_rule || null;
+  }
+
+  /**
+   * Get access rules
+   */
+  public async getAccessRules(roomId: string): Promise<any> {
+    const state = await this.getRoomState(roomId);
+    return state['im.vector.room.access_rules'] || null;
+  }
+
+  /**
+   * Send a state event to a room
+   */
+  public async sendStateEvent<K extends keyof StateEvents>(
+    roomId: string,
+    eventType: K,
+    content: StateEvents[K],
+    stateKey: string = ''
+  ): Promise<any> {
+    return this.client.sendStateEvent(roomId, eventType, content, stateKey);
+  }
+
+  /**
+   * Logout
+   */
+  public async logout(): Promise<void> {
+    await this.client.logout();
+  }
+}


### PR DESCRIPTION

https://github.com/tchapgouv/synapse-room-access-rules/releases/tag/v1.2.2rc2

- test create room and allow events in dev environnement
- 100% API calls via matrix-js-sdk
- playwright is only used to run tests
- reuse of mas-api